### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-- Install Java 8
+- Install Java 9
 - Run `make`
 - Run `make test` (optional)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-- Install Java 9
+- Install Java 11
 - Run `make`
 - Run `make test` (optional)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ## Command Line Arguments
 
 - `-simplify`: apply some normalization and simplification (unstable)
+- `-prove`: reduce the last assertion to its unprovable parts
 - `-format`: format output script with indentation and lots of newlines
 - `-timeout <ms>`: timeout per solver query (default: 1000)
 - `-test`: honor `(set-info :status <...>)` and rise error on mismatch


### PR DESCRIPTION
- Java 8 doesn't suffice. We need Java 9. However, we test with 11 and that's also the current LTS version, so I suggest putting 11.
- Added -prove flag to command line arguments